### PR TITLE
Fix relatives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - cd ..
 
 script:
-  - gostatic config
+  - gostatic -fv config
 
 after_success:
   - cd site

--- a/templates/post-preview.tmpl
+++ b/templates/post-preview.tmpl
@@ -3,19 +3,19 @@
 	<small class="date">{{ .Date.Format "January _2, 2006" }}</small>
 
 	{{ if .Other.Author_name }}
-		<a href="{{ .Url }}"><img class="author" src="{{ .Other.Author_avatar }}" alt="{{ .Other.Author_name }}" title="{{ .Other.Author_name }}"></a>
+		<a href="{{ .UrlTo .  }}"><img class="author" src="{{ .Other.Author_avatar }}" alt="{{ .Other.Author_name }}" title="{{ .Other.Author_name }}"></a>
 	{{ else if .Other.Author }}
 		{{ $name := index .Site.Other (print .Other.Author "_name") }}
 		{{ $avatar := index .Site.Other (print .Other.Author "_avatar") }}
-		<a href="{{ .Url }}"><img class="author" src="{{ $avatar }}" alt="{{ $name }}" title="{{ $name }}"></a>
+		<a href="{{ .UrlTo .  }}"><img class="author" src="{{ $avatar }}" alt="{{ $name }}" title="{{ $name }}"></a>
 	{{ end }}
 
 	<h1 class="title">
-		<a href="{{ .Url }}">{{ .Title | html }}</a>
+		<a href="{{ .UrlTo .  }}">{{ .Title | html }}</a>
 	</h1>
 	
 	{{ if .Other.Header_image }}
-		<p><a href="{{ .Url }}"><img data-src="https://iwmn-blog.imgix.net/{{ .Other.Header_image }}" class="imgix-fluid" alt="{{ .Title | html }}" title="{{ .Title | html }}"></a></p>
+		<p><a href="{{ .UrlTo .  }}"><img data-src="https://iwmn-blog.imgix.net/{{ .Other.Header_image }}" class="imgix-fluid" alt="{{ .Title | html }}" title="{{ .Title | html }}"></a></p>
 	{{ end }}
 	{{ if .Other.Author_name }}
 		<p class="small text-muted">The following is a guest post written by {{ .Other.Author_name }}.</p>
@@ -26,7 +26,7 @@
 	{{ else }}
 		{{ template "excerpt" . }}
 		<p class="read-more">
-			<a href="{{ .Url }}" class="btn iwmn-btn btn-small">Read more &rarr;</a>
+			<a href="{{ .UrlTo .  }}" class="btn iwmn-btn btn-small">Read more &rarr;</a>
 		</p>
 	{{ end }}
 </article>


### PR DESCRIPTION
Hello.

Because of paginator, some your urls, after index page  lead to 404 error.

I.e. from [/blog/page-2/](https://iwantmyname.com/blog/page-2/) relative link [2015/04/reach-an-international-audience-with-these-country-code-top-level-domains.html](2015/04/reach-an-international-audience-with-these-country-code-top-level-domains.html) lead to [/blog/page-2/2015/04/reach-an-international-audience-with-these-country-code-top-level-domains.html](/blog/page-2/2015/04/reach-an-international-audience-with-these-country-code-top-level-domains.html).

I'm fixed most important links. But popular block need to fixes. 

You use fork of gostatic?

I'm cannot run clone of your blog on local machine.

